### PR TITLE
Improve test runner exit codes

### DIFF
--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -193,13 +193,18 @@ async function main() {
     return;
   }
   
+  let success;
+
   if (testName === 'all') {
-    await runAllTests();
+    success = await runAllTests();
   } else if (testName === 'interactive') {
     showInteractiveMenu();
+    return;
   } else {
-    await runTest(testName);
+    success = await runTest(testName);
   }
+
+  process.exit(success ? 0 : 1);
 }
 
 // Run the main function


### PR DESCRIPTION
## Summary
- modify `tests/run-tests.js` to exit with the proper status code
- keep interactive mode unaffected

## Testing
- `printf '0\n' | npm test`

------
https://chatgpt.com/codex/tasks/task_e_684492deb9d88321bfa188aa6cc1df03